### PR TITLE
The solarized-dark theme was being loaded in two different places in …

### DIFF
--- a/init.el
+++ b/init.el
@@ -49,12 +49,7 @@
 (use-package solarized-theme
   :ensure t ; Ensure it's installed
   :config
-  ;; Load theme, handling daemon case if necessary (using logic from early-init is better)
-  ;; Simple version:
-  (when (display-graphic-p)
-     (load-theme 'solarized-dark t))
-  ;; Consider moving the daemon-aware loading logic from early-init here if preferred
-  )
+  (load-theme 'solarized-dark t))
 
 ;; In init.el
 (use-package markdown-mode
@@ -182,12 +177,6 @@
 
 
 ;; --- Finalization ---
-;; Remove misplaced theme loading code from original snippet
-;; :config
-(message "[Theme Debug] Attempting to load solarized-dark...")
-(load-theme 'solarized-dark t)
-(message "[Theme Debug] Theme load attempt finished.")
-
 (message "Michaël's Emacs configuration loaded successfully.")
 
 ;;; init.el ends here


### PR DESCRIPTION
…init.el, leading to redundancy and inconsistent behavior.

The first load was inside the `use-package` block for `solarized-theme`, but it was conditional on running in a graphical session. The second load was unconditional at the end of the file. A comment indicated this second load was misplaced.

This commit consolidates the theme loading by:
1.  Removing the conditional logic within the `use-package` block.
2.  Making the theme load unconditional within the `use-package` block's `:config` section.
3.  Removing the redundant and misplaced `load-theme` call from the end of the file.

This ensures the theme is loaded exactly once, idiomatically, and consistently across both graphical and terminal Emacs sessions.

A formal test case was not added as the repository does not have a testing framework for its Emacs Lisp configuration files. The fix was verified by inspecting the final state of `init.el` to ensure its correctness.