### PR TITLE
feat: Add gemini-cli integration for Emacs

### DIFF
--- a/init.el
+++ b/init.el
@@ -115,6 +115,7 @@
 (require 'pkg-eshell)         ; Eshell enhancements
 (require 'pkg-multipleCursor) ; multiple-cursors setup
 (require 'pkg-search)         ; Search tools (Consult, etc.)
+(require 'pkg-gemini)         ; gemini-cli integration
 ;; ... add require lines for all other pkg-*.el files you use ...
 ;; (require 'pkg-ssh)
 ;; (require 'pkg-latex)

--- a/packages/pkg-gemini.el
+++ b/packages/pkg-gemini.el
@@ -1,0 +1,22 @@
+;; -*- lexical-binding: t; -*-
+
+(require 'use-package)
+
+;; for eat terminal backend:
+(use-package eat
+  :ensure t
+  :defer t)
+
+;; for slash commands popup
+(use-package popup
+  :ensure t
+  :defer t)
+
+;; install gemini-cli.el
+(use-package gemini-cli
+  :ensure t
+  :vc (:url "https://github.com/linchen2chris/gemini-cli.el" :rev :newest)
+  :config (gemini-cli-mode)
+  :bind-keymap ("C-c c" . gemini-cli-command-map))
+
+(provide 'pkg-gemini)


### PR DESCRIPTION
This PR adds the `gemini-cli.el` package to the user's Emacs configuration. It allows for integrated access to the Gemini CLI, facilitating "vibe coding" directly from Emacs. The package requires `eat` and `popup`, which are configured accordingly.

---
*PR created automatically by Jules for task [5546090920836156927](https://jules.google.com/task/5546090920836156927) started by @mikefaille*